### PR TITLE
passing in network to toWIF

### DIFF
--- a/bip39-standalone.html
+++ b/bip39-standalone.html
@@ -22942,7 +22942,7 @@ WORDLISTS = {
             var index = i+ start;
             var key = bip32ExtendedKey.derive(index);
             var address = key.getAddress().toString();
-            var privkey = key.privKey.toWIF();
+            var privkey = key.privKey.toWIF(network);
             addAddressToList(index, address, privkey);
         }
     }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -241,7 +241,7 @@
             var index = i+ start;
             var key = bip32ExtendedKey.derive(index);
             var address = key.getAddress().toString();
-            var privkey = key.privKey.toWIF();
+            var privkey = key.privKey.toWIF(network);
             addAddressToList(index, address, privkey);
         }
     }


### PR DESCRIPTION
Passing in the network to the toWIF function, otherwise the WIF is always bitcoin. I was testing and overriding the network variable to testnet and noticed incorrect private keys being generated even though correct testnet addresses were being generated.
