### PR TITLE
Support identifying mnemonic word by the first four unique characters

### DIFF
--- a/bip39-standalone.html
+++ b/bip39-standalone.html
@@ -18648,7 +18648,7 @@ window.Entropy = new (function() {
     // mnemonics is populated as required by getLanguage
     var mnemonics = { "english": new Mnemonic("english") };
     var mnemonic = mnemonics["english"];
-    var seed = null
+    var seed = null;
     var bip32RootKey = null;
     var bip32ExtendedKey = null;
     var network = bitcoin.networks.bitcoin;
@@ -18663,6 +18663,8 @@ window.Entropy = new (function() {
     var entropyChangeTimeoutEvent = null;
     var phraseChangeTimeoutEvent = null;
     var rootKeyChangedTimeoutEvent = null;
+
+    var wordlistLookups = {};
 
     var DOM = {};
     DOM.network = $(".network");
@@ -18745,6 +18747,7 @@ window.Entropy = new (function() {
         hidePending();
         hideValidationError();
         populateNetworkSelect();
+        createWordlistLookups();
     }
 
     // Event handlers
@@ -19287,6 +19290,10 @@ window.Entropy = new (function() {
 
     function findNearestWord(word) {
         var language = getLanguage();
+        if (word in wordlistLookups[language]) {
+            return wordlistLookups[language][word];
+        }
+
         var words = WORDLISTS[language];
         var minDistance = 99;
         var closestWord = words[0];
@@ -19330,6 +19337,50 @@ window.Entropy = new (function() {
             language = defaultLanguage;
         }
         return language;
+    }
+
+    function getPrefix(word) {
+        // for most languages, 4 characters is enough to determine the word
+        var charactersToTake = 4;
+        var prefix = '';
+
+        var characters = word.split('');
+        for (var i = 0; i < characters.length; i++) {
+            var c = characters[i];
+            if (c.charCodeAt(0) > 122) charactersToTake += 1;
+            if (prefix.length < charactersToTake) prefix += c;
+            else break;
+        }
+        return prefix;
+    }
+
+    function canLookup(wordlist) {
+        // can't perform a lookup for languages which have characters past latin diacritical
+        const maxCharCode = 879;
+
+        for (var wi = 0; wi < wordlist.length; wi++) {
+            var word = wordlist[wi];
+            for (var ci = 0; ci < word.length; ci++) {
+                if (word.charCodeAt(ci) > maxCharCode) return false;
+            }
+        }
+        return true;
+    }
+
+    function createWordlistLookups() {
+        for (var l in WORDLISTS) {
+            const words = WORDLISTS[l];
+
+            if (!canLookup(words)) {
+                wordlistLookups[l] = {};
+                continue;
+            }
+
+            wordlistLookups[l] = words.reduce(function (prefixes, word) {
+                if (word.length > 4) prefixes[getPrefix(word)] = word;
+                return prefixes;
+            }, {});
+        }
     }
 
     function getLanguageFromPhrase(phrase) {


### PR DESCRIPTION
As far as I'm aware, this feature only exists in latin alphabet wordlists, so I exclude any wordlists with character codes beyond the latin combining diacritical marks. This way it's more future proof than going by the language string.

edit... Sorry for the notification spam, I accidentally closed the request.