### PR TITLE
Allow for better suggestion when a partial mnemonic word is entered

### DIFF
--- a/bip39-standalone.html
+++ b/bip39-standalone.html
@@ -18648,7 +18648,7 @@ window.Entropy = new (function() {
     // mnemonics is populated as required by getLanguage
     var mnemonics = { "english": new Mnemonic("english") };
     var mnemonic = mnemonics["english"];
-    var seed = null
+    var seed = null;
     var bip32RootKey = null;
     var bip32ExtendedKey = null;
     var network = bitcoin.networks.bitcoin;
@@ -19292,6 +19292,8 @@ window.Entropy = new (function() {
         var closestWord = words[0];
         for (var i=0; i<words.length; i++) {
             var comparedTo = words[i];
+            if (comparedTo.indexOf(word) == 0) return comparedTo;
+
             var distance = Levenshtein.get(word, comparedTo);
             if (distance < minDistance) {
                 closestWord = comparedTo;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -3,7 +3,7 @@
     // mnemonics is populated as required by getLanguage
     var mnemonics = { "english": new Mnemonic("english") };
     var mnemonic = mnemonics["english"];
-    var seed = null
+    var seed = null;
     var bip32RootKey = null;
     var bip32ExtendedKey = null;
     var network = bitcoin.networks.bitcoin;
@@ -647,6 +647,8 @@
         var closestWord = words[0];
         for (var i=0; i<words.length; i++) {
             var comparedTo = words[i];
+            if (comparedTo.indexOf(word) == 0) return comparedTo;
+
             var distance = Levenshtein.get(word, comparedTo);
             if (distance < minDistance) {
                 closestWord = comparedTo;


### PR DESCRIPTION
Currently, entering _ille_ suggests _idle_ since the edit distance is shortest. However, those four characters are enough to uniquely identify the correct mnemonic word _illegal_. This small change skips the remaining edit distance checks if the entered word is found at the beginning of one of the wordlist words.

Sorry about the other pull request, I had come up with a far more complicated solution and as I was creating the pull request I realized there was a better way. 😄