### PR TITLE
Deleting the remaining checksum from the Ripple private key

### DIFF
--- a/src/js/ripple-util.js
+++ b/src/js/ripple-util.js
@@ -5,6 +5,6 @@ function convertRippleAdrr(address) {
       }
 
 function convertRipplePriv(priv)   {
-        return window.basex('123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz').decode(priv).toString("hex").slice(2,-4)
+        return window.basex('123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz').decode(priv).toString("hex").slice(2,66)
 }   
       

--- a/src/js/ripple-util.js
+++ b/src/js/ripple-util.js
@@ -5,6 +5,6 @@ function convertRippleAdrr(address) {
       }
 
 function convertRipplePriv(priv)   {
-        return window.basex('123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz').decode(priv).toString("hex").slice(2)
+        return window.basex('123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz').decode(priv).toString("hex").slice(2,-4)
 }   
       


### PR DESCRIPTION
The checksum was mistakenly still attached to the hexadecimal format of the ripple private key