### PR TITLE
remove sourceMappingURL=zxcvbn.js.map

### DIFF
--- a/src/js/zxcvbn.js
+++ b/src/js/zxcvbn.js
@@ -25,4 +25,4 @@ var time_estimates;time_estimates={estimate_attack_times:function(e){var t,n,s,o
 
 },{}]},{},[4])(4)
 });
-//# sourceMappingURL=zxcvbn.js.map
+


### PR DESCRIPTION
just remove this line, if not every time we run the converter it searches for the map file. It is not enough to uncomment this line.

If it runs from server direct you get an 404 error which will ban on our side the user if he has to many 404 on our services. But I think everyone run into this 404

thx