### PR TITLE
Allowing compilation with Python 2.x

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -1,6 +1,7 @@
 import os
 import re
 import datetime
+from io import open
 
 # This script generates the bip39-standalone.html file.
 


### PR DESCRIPTION
This allows python 2's `open` to work like python 3 (with `encoding` argument).
In python3 `open` from `io` is an alias for the built-in `open` so there is no functional change.
I did not see any encoding changes, etc when using with 2.7