### PR TITLE
update PIVX hd derivation path to m/44'/77'

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1513,7 +1513,7 @@
             segwitAvailable: false,
             onSelect: function() {
                 network = bitcoinjs.bitcoin.networks.pivx;
-                setHdCoin(119);
+                setHdCoin(77);
             },
         },
         {


### PR DESCRIPTION
77 is the coin number Ledger Wallet uses.
Still 119 is used by coinomi. Maybe leave this field editable?