### PR TITLE
feat: Add optional visual screen privacy safeguard for private data.

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -95,6 +95,10 @@ body {
     top: 5px;
     right: 5px;
 }
+.visual-privacy {
+    color: grey !important;
+    background-color: grey !important;
+}
 .csv {
     margin-top: 20px;
     margin-bottom: 20px;

--- a/src/index.html
+++ b/src/index.html
@@ -131,9 +131,9 @@
                             </div>
                         </div>
                         <div class="form-group">
-                                <label for="phrase" class="col-sm-2 control-label">Hide All Private Info</label>
+                                <label for="visual-screen-privacy" class="col-sm-2 control-label">Hide All Private Info</label>
                                 <div class="col-sm-10">
-                                    <input type="checkbox" id="visual-screen-privacy" class="phrase form-control" style="width: 30px;" />
+                                    <input type="checkbox" id="visual-screen-privacy" class="form-control" style="width: 30px;" />
                                 </div>
                             </div>
                         <div class="form-group">

--- a/src/index.html
+++ b/src/index.html
@@ -131,6 +131,12 @@
                             </div>
                         </div>
                         <div class="form-group">
+                                <label for="phrase" class="col-sm-2 control-label">Hide All Private Info</label>
+                                <div class="col-sm-10">
+                                    <input type="checkbox" id="visual-screen-privacy" class="phrase form-control" style="width: 30px;" />
+                                </div>
+                            </div>
+                        <div class="form-group">
                             <label class="col-sm-2 control-label">Mnemonic Language</label>
                             <div class="col-sm-10 languages">
                                 <div class="form-control no-border">
@@ -147,13 +153,13 @@
                         <div class="form-group">
                             <label for="phrase" class="col-sm-2 control-label">BIP39 Mnemonic</label>
                             <div class="col-sm-10">
-                                <textarea id="phrase" class="phrase form-control" data-show-qr></textarea>
+                                <textarea id="phrase" class="private-data phrase form-control" data-show-qr></textarea>
                             </div>
                         </div>
                         <div class="form-group">
                             <label for="passphrase" class="col-sm-2 control-label">BIP39 Passphrase (optional)</label>
                             <div class="col-sm-10">
-                                <textarea id="passphrase" class="passphrase form-control"></textarea>
+                                <textarea id="passphrase" class="private-data passphrase form-control"></textarea>
                             </div>
                         </div>
                         <div class="form-group">
@@ -266,7 +272,7 @@
                                         <span>Account Extended Private Key</span>
                                     </label>
                                     <div class="col-sm-10">
-                                        <textarea id="account-xprv" type="text" class="account-xprv form-control" readonly data-show-qr></textarea>
+                                        <textarea id="account-xprv" type="text" class="private-data account-xprv form-control" readonly data-show-qr></textarea>
                                     </div>
                                 </div>
                                 <div class="form-group">
@@ -426,7 +432,7 @@
                                             <span>Account Extended Private Key</span>
                                         </label>
                                         <div class="col-sm-10">
-                                            <textarea id="account-xprv" type="text" class="account-xprv form-control" readonly data-show-qr></textarea>
+                                            <textarea id="account-xprv" type="text" class="private-data account-xprv form-control" readonly data-show-qr></textarea>
                                         </div>
                                     </div>
                                     <div class="form-group">
@@ -575,7 +581,7 @@
                         <div class="form-group">
                             <label for="extended-priv-key" class="col-sm-2 control-label">BIP32 Extended Private Key</label>
                             <div class="col-sm-10">
-                                <textarea id="extended-priv-key" class="extended-priv-key form-control" readonly="readonly" data-show-qr></textarea>
+                                <textarea id="extended-priv-key" class="private-data extended-priv-key form-control" readonly="readonly" data-show-qr></textarea>
                             </div>
                         </div>
                         <div class="form-group">
@@ -609,7 +615,7 @@
                             <input type="checkbox" class="use-bip38">
                             <span>Encrypt private keys using BIP38 and this password:</span>
                         </label>
-                        <input class="bip38-password">
+                        <input class="bip38-password private-data">
                         <span>Enabling BIP38 means each key will take take several minutes to generate.</span>
                     </div>
                 </div>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -40,6 +40,7 @@
     DOM.entropyWordIndexes = DOM.entropyContainer.find(".word-indexes");
     DOM.entropyMnemonicLength = DOM.entropyContainer.find(".mnemonic-length");
     DOM.entropyFilterWarning = DOM.entropyContainer.find(".filter-warning");
+    DOM.privacyCheckbox = $("#visual-screen-privacy");
     DOM.phrase = $(".phrase");
     DOM.passphrase = $(".passphrase");
     DOM.generateContainer = $(".generate-container");
@@ -118,6 +119,7 @@
         DOM.useEntropy.on("change", setEntropyVisibility);
         DOM.entropy.on("input", delayedEntropyChanged);
         DOM.entropyMnemonicLength.on("change", entropyChanged);
+        DOM.privacyCheckbox.on("change", visualScreenPrivacySettingChaged)
         DOM.phrase.on("input", delayedPhraseChanged);
         DOM.passphrase.on("input", delayedPhraseChanged);
         DOM.generate.on("click", generateClicked);
@@ -304,6 +306,14 @@
         }
         else {
             hidePending();
+        }
+    }
+
+    function visualScreenPrivacySettingChaged(event) {
+        if (event.target.checked) {
+            $('.private-data').addClass('visual-privacy');
+        } else {
+            $('.private-data').removeClass('visual-privacy');
         }
     }
 
@@ -1314,7 +1324,14 @@
         els.on("click", toggleQr);
     }
 
+    function privacyBoxIsChecked() {
+        return !!DOM.privacyCheckbox[0].checked;
+    }
+
     function createQr(e) {
+        if (privacyBoxIsChecked()) {
+            return;
+        }
         var content = e.target.textContent || e.target.value;
         if (content) {
             var qrEl = kjua({
@@ -1340,6 +1357,9 @@
     }
 
     function toggleQr() {
+        if (privacyBoxIsChecked()) {
+            return;
+        }
         showQr = !showQr;
         DOM.qrHider.toggleClass("hidden");
         DOM.qrHint.toggleClass("hidden");


### PR DESCRIPTION
# Summary

This adds a simple checkbox form element, to enable the user to visually hide the private info on the page.

# Motivation

Consider a scenario where a more technical person is helping someone verify their 24 word recovery phrase for their hardware wallet.  The technical person would typically need to help verify the generated hash addresses, to make sure that the 24 words were correct.

In this scenario, ideally, the owner of the hardware wallet should be able to hide the recovery phrase and qr code from view.  That way, the assistant can look at the bip39 page to verify the non-private hash addresses without seeing the hardware wallet owner's private info.

# Tests

At this point, both iancoleman/bip39 master branch and my fork produce these results on my box, which all seem to be due to the test tool's timeout being too short for my local set-up (I am running a laptop with only small graphics capability, so perhaps that is affecting the tests):

```
Using default browser: chrome
Started
...............................................................**..........FF.....F........................................................................FF....................F...............

```

I tried a larger `jasmine.DEFAULT_TIMEOUT_INTERVAL` and other intervals, but even at sixteen times the intervals that still left three failures for both the original and this fork:
```
...............................................................**.................F.......F................................................................F.....................................

```
I've attached text files showing the complete logs for the test run on both the original and this fork.  The only issues seem to be due to timeouts.

Here's what I did to try to eliminate the timeouts:

```
// Slower computer factor: Required to run tests on slower machines.
var SLOWER_FACTOR = 16;

// Jasmine Settings
jasmine.DEFAULT_TIMEOUT_INTERVAL *= SLOWER_FACTOR;
....
// Delays in ms
var generateDelay = 1500 * SLOWER_FACTOR;
var feedbackDelay = 500 * SLOWER_FACTOR;
var entropyFeedbackDelay = 500 * SLOWER_FACTOR;
var bip38delay = 15000 * SLOWER_FACTOR;

```

It seems that since both master and my fork produce the same test result, my change is orthogonal to any test issues.  Those test issues would seem to be a separate topic.  

![privacy-screenshot from 2018-02-10 01-17-21](https://user-images.githubusercontent.com/308863/36060538-7e8c449a-0e00-11e8-8f5c-b36f08cad841.png)


![privacy-screenshot from 2018-02-10 01-18-03](https://user-images.githubusercontent.com/308863/36060539-84621aac-0e00-11e8-85fd-cda2cb0813a6.png)

[test-logs-original-iancoleman.txt](https://github.com/iancoleman/bip39/files/1713870/test-logs-original-iancoleman.txt)

[test-logs-treelogic-swe-fork.txt](https://github.com/iancoleman/bip39/files/1713871/test-logs-treelogic-swe-fork.txt)
