### PR TITLE
Implemented support for Beetle Coin

### DIFF
--- a/src/js/bitcoinjs-extensions.js
+++ b/src/js/bitcoinjs-extensions.js
@@ -361,3 +361,14 @@ bitcoinjs.bitcoin.networks.blackcoin = {
   scriptHash: 0x55,
   wif: 0x99
 };
+
+bitcoinjs.bitcoin.networks.beetlecoin = {
+  messagePrefix: '\x19Beetlecoin Signed Message:\n',
+  bip32: {
+    public: 0x0488b21e,
+    private: 0x0488ade4
+  },
+  pubKeyHash: 0x1A,
+  scriptHash: 0x55,
+  wif: 0x99,
+};

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1523,6 +1523,14 @@
             },
         },
         {
+            name: "BEET - Beetlecoin",
+            segwitAvailable: false,
+            onSelect: function() {
+                network = bitcoinjs.bitcoin.networks.beetlecoin;
+                setHdCoin(800);
+            },
+        },
+        {
             name: "BCH - Bitcoin Cash",
             segwitAvailable: false,
             onSelect: function() {


### PR DESCRIPTION
Hi. We are currently developing a BIP39/BIP44 HD wallet for Beetle Coin, and if possible, it would be appreciated if this pull request which adds support for BEET could be accepted. We already have an official coin type listing on https://github.com/satoshilabs/slips/blob/master/slip-0044.md, which will confirm our coin type configuration submitted here. 