### PR TITLE
Prohibit using short mnemonics

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -39,8 +39,6 @@
                                         <span>Generate a random mnemonic, or enter your own below</span>:
                                         <button class="btn generate">Generate</button>
                                         <select id="strength" class="strength form-control">
-                                            <option value="3">3</option>
-                                            <option value="6">6</option>
                                             <option value="9">9</option>
                                             <option value="12">12</option>
                                             <option value="15" selected>15</option>


### PR DESCRIPTION
Mnemonics under 9 words (96 bits) have very low entropy and can be easily bruteforced.
Why are they even allowed?!