### PR TITLE
mod fujicoin SegWit

### DIFF
--- a/src/js/segwit-parameters.js
+++ b/src/js/segwit-parameters.js
@@ -68,4 +68,30 @@ bitcoinjs.bitcoin.networks.litecoin.p2wpkhInP2sh = {
     wif: 0xb0
 };
 
+bitcoinjs.bitcoin.networks.fujicoin.p2wpkh = {
+    baseNetwork: "fujicoin",
+    messagePrefix: '\x19FujiCoin Signed Message:\n',
+    bech32: 'fc',
+    bip32: {
+        public: 0x04b24746,
+        private: 0x04b2430c
+    },
+    pubKeyHash: 0x24,
+    scriptHash: 0x10,
+    wif: 0xa4
+};
+
+bitcoinjs.bitcoin.networks.fujicoin.p2wpkhInP2sh = {
+    baseNetwork: "fujicoin",
+    messagePrefix: '\x19FujiCoin Signed Message:\n',
+    bech32: 'fc',
+    bip32: {
+        public: 0x049d7cb2,
+        private: 0x049d7878
+    },
+    pubKeyHash: 0x24,
+    scriptHash: 0x10,
+    wif: 0xa4
+};
+
 })();


### PR DESCRIPTION
Fujicoin has completed activation of SegWit. Along with this, we updated electrum-FJC to support SegWit and confirmed remittance with Bech32 SegWit address.
Electrum-FJC is available from official website.
http://www.fujicoin.org/downloads.php

SegWit hrp is "fc".
Other parameters are the same as Bitcoin.
https://github.com/fujicoin/electrum-fjc-3.1.2/blob/4447cd77daa1b6fef3348d81520f0075268e5af4/lib/constants.py#L46

Please consider Fujicoin SegWit correspondence.