### PR TITLE
Fix incorrect address generation for altcoins with BIP38 enabled

### DIFF
--- a/src/js/bitcoinjs-3.3.2.js
+++ b/src/js/bitcoinjs-3.3.2.js
@@ -8642,7 +8642,7 @@ function fromBase58Check (address) {
 
   // TODO: 4.0.0, move to "toOutputScript"
   if (payload.length < 21) throw new TypeError(address + ' is too short')
-  if (payload.length > 22) throw new TypeError(address + ' is too long')
+  if (payload.length > 21) throw new TypeError(address + ' is too long')
 
   var version = payload.readUInt8(0)
   var hash = payload.slice(1)

--- a/src/js/bitcoinjs-3.3.2.js
+++ b/src/js/bitcoinjs-3.3.2.js
@@ -8642,7 +8642,7 @@ function fromBase58Check (address) {
 
   // TODO: 4.0.0, move to "toOutputScript"
   if (payload.length < 21) throw new TypeError(address + ' is too short')
-  if (payload.length > 21) throw new TypeError(address + ' is too long')
+  if (payload.length > 22) throw new TypeError(address + ' is too long')
 
   var version = payload.readUInt8(0)
   var hash = payload.slice(1)

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -813,7 +813,7 @@
                 var keyPair = key.keyPair;
                 var useUncompressed = useBip38;
                 if (useUncompressed) {
-                    keyPair = new bitcoinjs.bitcoin.ECPair(keyPair.d, null, { compressed: false });
+                    keyPair = new bitcoinjs.bitcoin.ECPair(keyPair.d, null, { network: network, compressed: false });
                 }
                 // get address
                 var address = keyPair.getAddress().toString();
@@ -821,7 +821,7 @@
                 var hasPrivkey = !key.isNeutered();
                 var privkey = "NA";
                 if (hasPrivkey) {
-                    privkey = keyPair.toWIF(network);
+                    privkey = keyPair.toWIF();
                     // BIP38 encode private key if required
                     if (useBip38) {
                         privkey = bitcoinjsBip38.encrypt(keyPair.d.toBuffer(), false, bip38password, function(p) {


### PR DESCRIPTION
This PR fixes a bug which causes addresses to be incorrect for altcoins when BIP38 is enabled.