### PR TITLE
SYScoin fix for WIF private address format

### DIFF
--- a/src/js/bitcoinjs-extensions.js
+++ b/src/js/bitcoinjs-extensions.js
@@ -1064,7 +1064,7 @@ bitcoinjs.bitcoin.networks.syscoin = {
   },
   pubKeyHash: 0x3f,
   scriptHash: 0x05,
-  wif: 0xbf,
+  wif: 0x80,
 };
 
 


### PR DESCRIPTION
Your current syscoin private key format won't import. Here is updated tested version