### PR TITLE
Fix wrong addresses for BTDX and MEC

### DIFF
--- a/tests/spec/tests.js
+++ b/tests/spec/tests.js
@@ -707,7 +707,7 @@ it('Allows selection of Bitcoinz', function(done) {
 it('Allows selection of BitCloud', function(done) {
     var params = {
         selectText: "BTDX - BitCloud",
-        firstAddress: "BE9tnWxiR7ALgVhG8LLDi2W9pvtjzZMFoM",
+        firstAddress: "BHbWitXCNgTf1BhsRDNMP186EeibuzmrBi",
     };
     testNetwork(done, params);
 });
@@ -966,7 +966,7 @@ it('Allows selection of Lynx', function(done) {
 it('Allows selection of Megacoin', function(done) {
     var params = {
         selectText: "MEC - Megacoin",
-        firstAddress: "MHHRRPHcF8DvQpEySFF9M6fR8Qv4JH2fFC",
+        firstAddress: "MDfAj9CzkC1HpcUiVGnHp8yKTa7WXgu8AY",
     };
     testNetwork(done, params);
 });


### PR DESCRIPTION
I checked the addresses with this tool: https://github.com/dan-da/hd-wallet-derive
But I have made a mistake in my application of the tool.

Here are the correct addresses:

**BTDX**
```
./hd-wallet-derive.php --coin=btdx --path="m/44'/218'/0'/0" --mnemonic="abandon abandon ability" -g --includeroot  --numderive=1 --cols=path,address

+-------------------+------------------------------------+
| path              | address                            |
+-------------------+------------------------------------+
| m                 | BRC7JuAqoZ6aHrdMFFFN9XRSpER1XQjny2 |
| m/44'/218'/0'/0/0 | BHbWitXCNgTf1BhsRDNMP186EeibuzmrBi |
+-------------------+------------------------------------+
```

**MEC**
```
./hd-wallet-derive.php --coin=mec --path="m/44'/217'/0'/0" --mnemonic="abandon abandon ability" -g --includeroot  --numderive=1 --cols=path,address

+-------------------+------------------------------------+
| path              | address                            |
+-------------------+------------------------------------+
| m                 | MUeBvcd3Z4gUjh7WrjaLGfE7YqrbFn1Le5 |
| m/44'/217'/0'/0/0 | MDfAj9CzkC1HpcUiVGnHp8yKTa7WXgu8AY |
+-------------------+------------------------------------+
```