### PR TITLE
Allow converting mnemonic back to raw entropy value

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -232,7 +232,14 @@
         if (phraseChangeTimeoutEvent != null) {
             clearTimeout(phraseChangeTimeoutEvent);
         }
-        phraseChangeTimeoutEvent = setTimeout(phraseChanged, 400);
+        phraseChangeTimeoutEvent = setTimeout(function() {
+            phraseChanged();
+            var entropy = mnemonic.toRawEntropyHex(DOM.phrase.val());
+            if (entropy !== null) {
+                DOM.entropyMnemonicLength.val("raw");
+                DOM.entropy.val(entropy);
+            }
+        }, 400);
     }
 
     function phraseChanged() {

--- a/src/js/jsbip39.js
+++ b/src/js/jsbip39.js
@@ -97,22 +97,10 @@ var Mnemonic = function(language) {
     }
 
     self.check = function(mnemonic) {
-        var mnemonic = self.splitWords(mnemonic);
-        if (mnemonic.length == 0 || mnemonic.length % 3 > 0) {
-            return false
+        var b = mnemonicToBinaryString(mnemonic);
+        if (b === null) {
+            return false;
         }
-        // idx = map(lambda x: bin(self.wordlist.index(x))[2:].zfill(11), mnemonic)
-        var idx = [];
-        for (var i=0; i<mnemonic.length; i++) {
-            var word = mnemonic[i];
-            var wordIndex = wordlist.indexOf(word);
-            if (wordIndex == -1) {
-                return false;
-            }
-            var binaryIndex = zfill(wordIndex.toString(2), 11);
-            idx.push(binaryIndex);
-        }
-        var b = idx.join('');
         var l = b.length;
         //d = b[:l / 33 * 32]
         //h = b[-l / 33:]
@@ -126,6 +114,20 @@ var Mnemonic = function(language) {
         var ndBstr = zfill(hexStringToBinaryString(ndHex), 256);
         var nh = ndBstr.substring(0,l/33);
         return h == nh;
+    }
+
+    self.toRawEntropyHex = function(mnemonic) {
+        var b = mnemonicToBinaryString(mnemonic);
+        if (b === null)
+            return null;
+        var d = b.substring(0, b.length / 33 * 32);
+        var nd = binaryStringToWordArray(d);
+
+        var h = "";
+        for (var i=0; i<nd.length; i++) {
+            h += ('0000000' + nd[i].toString(16)).slice(-8);
+        }
+        return h;
     }
 
     self.toSeed = function(mnemonic, passphrase) {
@@ -198,6 +200,25 @@ var Mnemonic = function(language) {
             binary = binary.slice(32);
         }
         return a;
+    }
+
+    function mnemonicToBinaryString(mnemonic) {
+        var mnemonic = self.splitWords(mnemonic);
+        if (mnemonic.length == 0 || mnemonic.length % 3 > 0) {
+            return null;
+        }
+        // idx = map(lambda x: bin(self.wordlist.index(x))[2:].zfill(11), mnemonic)
+        var idx = [];
+        for (var i=0; i<mnemonic.length; i++) {
+            var word = mnemonic[i];
+            var wordIndex = wordlist.indexOf(word);
+            if (wordIndex == -1) {
+                return null;
+            }
+            var binaryIndex = zfill(wordIndex.toString(2), 11);
+            idx.push(binaryIndex);
+        }
+        return idx.join('');
     }
 
     // Pad a numeric string on the left with zero digits until the given width


### PR DESCRIPTION
Currently, this sequence produces an unexpected result:

1) Navigate to bip39-standalone.html

2) Paste a known-good mnemonic into the BIP39 Mnemonic field

3) Select "Show entropy details"

This will erase the BIP39 Mnemonic field and most of the derived address/key information.  It shows an empty Entropy field, and zeroes for Event Count, Bits Per Event, Raw Entropy Words, Total Bits, etc. However, it will show valid Word Indexes and BIP39 Seed.

The way to fix it is to convert the mnemonic back into a raw entropy value and populate it in DOM.entropy, so that everything stays consistent.  This will only happen if the mnemonic is manually entered by the user, not if phraseChanged() is triggered by hand-editing the entropy value.