### PR TITLE
Proposing sha256 versioned output file name bip39-standalone-xxxxxx.html - can be useful for replacement previous knowing what version is it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 bip39-standalone.html
+bip39-standalone-*.html

--- a/compile.py
+++ b/compile.py
@@ -50,7 +50,7 @@ for f in glob.glob("bip39-standalone*.html"):
 
 hashedWord = hashlib.sha256(page.encode('utf-8')).hexdigest()
 
-f = open('bip39-standalone-v' + hashedWord[-6:] + '.html', 'w', encoding="utf-8")
+f = open('bip39-standalone-' + hashedWord[-6:] + '.html', 'w', encoding="utf-8")
 f.write(page)
 f.close()
 

--- a/compile.py
+++ b/compile.py
@@ -3,8 +3,9 @@ import re
 import datetime
 from io import open
 import hashlib
+import glob
 
-# This script generates the bip39-standalone.html file.
+# This script generates the bip39-standalone-xxxxxx.html versioned file.
 
 # It removes script and style tags and replaces with the file content.
 
@@ -40,7 +41,11 @@ for style in styles:
     styleTag = """<link rel="stylesheet" href="%s">""" % style
     page = page.replace(styleTag, styleContent)
 
-
+# Delete previous files
+	
+for f in glob.glob("bip39-standalone*.html"):
+    os.remove(f)
+	
 # Write the standalone file
 
 hashedWord = hashlib.sha256(page.encode('utf-8')).hexdigest()

--- a/compile.py
+++ b/compile.py
@@ -2,6 +2,7 @@ import os
 import re
 import datetime
 from io import open
+import hashlib
 
 # This script generates the bip39-standalone.html file.
 
@@ -42,7 +43,9 @@ for style in styles:
 
 # Write the standalone file
 
-f = open('bip39-standalone.html', 'w', encoding="utf-8")
+hashedWord = hashlib.sha256(page.encode('utf-8')).hexdigest()
+
+f = open('bip39-standalone-v' + hashedWord[-6:] + '.html', 'w', encoding="utf-8")
 f.write(page)
 f.close()
 


### PR DESCRIPTION
Proposing sha256 versioned output file name bip39-standalone-xxxxxx.html - can be useful for replacement previous knowing what version is it.

This is not about version number in the html file. This version will somewhat tie to git commit.  
It will create a file bip39-standalone-xxxxxx.html where xxxxxx is last 6 digits of sha256 checksum of a content of bip39-standalone.html file.
This way you can make sure you always have the latest version of the generator, or to recognize you have different version 

previous:
bip39-standalone-c1fb1d.html

new:
bip39-standalone-b7f1ab.html