### PR TITLE
Fixed PPC scriptHash

### DIFF
--- a/src/js/bitcoinjs-extensions.js
+++ b/src/js/bitcoinjs-extensions.js
@@ -104,7 +104,7 @@ bitcoinjs.bitcoin.networks.peercoin = {
     private: 0x0488ade4
   },
   pubKeyHash: 0x37,
-  scriptHash: 0x00, // TODO set this correctly
+  scriptHash: 0x75,
   wif: 0xb7
 };
 


### PR DESCRIPTION
Hello, in order to set `scriptHash` for PPC correctly, I took the information from the [Ledger](https://github.com/LedgerHQ/ledger-live-common/blob/master/src/data/cryptocurrencies.js#L1215) integration they made.

0x00 -> 0x75