### PR TITLE
Zencash renamed Horizen

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -2860,7 +2860,7 @@
             },
         },
         {
-            name: "ZEN - Zencash",
+            name: "ZEN - Horizen",
             onSelect: function() {
                 network = bitcoinjs.bitcoin.networks.zencash;
                 setHdCoin(121);

--- a/tests/spec/tests.js
+++ b/tests/spec/tests.js
@@ -1376,9 +1376,9 @@ it('Allows selection of Zclassic', function(done) {
     };
     testNetwork(done, params);
 });
-it('Allows selection of Zencash', function(done) {
+it('Allows selection of Horizen', function(done) {
     var params = {
-        selectText: "ZEN - Zencash",
+        selectText: "ZEN - Horizen",
         firstAddress: "znWh9XASyW2dZq5tck84wFjiwuqVysi7q3p",
     };
     testNetwork(done, params);


### PR DESCRIPTION
Zencash renamed Horizen in August 22 2018.
https://blog.horizen.global/horizen-biweekly-summarized-august-22nd-2018/