### PR TITLE
src/index.html: Change link to latest standalone release

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -871,9 +871,9 @@
                     on any offline computer.
                     </p>
                     <p>
-                    <span>Alternatively, download the file from the repository</span>
+                    <span>Alternatively, download the file from the latest GitHub release</span>
                     -
-                    <a href="https://github.com/iancoleman/bip39">https://github.com/iancoleman/bip39</a>
+                    <a href="https://github.com/iancoleman/bip39/releases/latest/">https://github.com/iancoleman/bip39/releases/latest/</a>
                     </p>
 
                 </div>


### PR DESCRIPTION
Because of https://github.com/iancoleman/bip39/issues/226 there is no in-tree html file. It is in Releases.