### PR TITLE
Changed Viacoin (VIA) Prefix form "viacoin" to "via"

### DIFF
--- a/src/js/segwit-parameters.js
+++ b/src/js/segwit-parameters.js
@@ -534,7 +534,7 @@ libs.bitcoin.networks.syscoin.p2wpkhInP2sh = {
 libs.bitcoin.networks.viacoin.p2wpkh = {
     baseNetwork: "viacoin",
 	messagePrefix: '\x18Viacoin Signed Message:\n',
-	bech32: 'viacoin',
+	bech32: 'via',
 	bip32: {
 		public: 0x0488b21e,
 		private: 0x0488ade4
@@ -547,7 +547,7 @@ libs.bitcoin.networks.viacoin.p2wpkh = {
 libs.bitcoin.networks.viacoin.p2wpkhInP2sh = {
 	baseNetwork: "viacoin",
 	messagePrefix: '\x18Viacoin Signed Message:\n',
-	bech32: 'viacoin',
+	bech32: 'via',
 	bip32: {
 		public: 0x0488b21e,
 		private: 0x0488ade4


### PR DESCRIPTION
Viacoin Core 0.16.3 added BIP173 (Bech32) Address support ("via1..." addresses), I could not find any references about "viacoin1..." addresses. 
The previous prefix also caused a different checksum to be generated in the addresses.