### PR TITLE
Add Terra (LUNA) support

### DIFF
--- a/src/js/cosmos-util.js
+++ b/src/js/cosmos-util.js
@@ -1,13 +1,13 @@
-function CosmosBufferToPublic(pubBuf) {
+function CosmosBufferToPublic(pubBuf, hrp = "cosmos") {
   const Buffer = libs.buffer.Buffer;
   const AminoSecp256k1PubkeyPrefix = Buffer.from("EB5AE987", "hex");
   const AminoSecp256k1PubkeyLength = Buffer.from("21", "hex");
   pubBuf = Buffer.concat([AminoSecp256k1PubkeyPrefix, AminoSecp256k1PubkeyLength, pubBuf]);
-  return libs.bech32.encode("cosmospub", libs.bech32.toWords(pubBuf));
+  return libs.bech32.encode(`${hrp}pub`, libs.bech32.toWords(pubBuf));
 }
 
-function CosmosBufferToAddress(pubBuf) {
+function CosmosBufferToAddress(pubBuf, hrp = "cosmos") {
   const sha256_ed = libs.createHash("sha256").update(pubBuf).digest();
   const ripemd160_ed = libs.createHash("rmd160").update(sha256_ed).digest();
-  return libs.bech32.encode("cosmos", libs.bech32.toWords(ripemd160_ed));
+  return libs.bech32.encode(hrp, libs.bech32.toWords(ripemd160_ed));
 }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1420,9 +1420,17 @@
                 }
 
                 if (networks[DOM.network.val()].name == "ATOM - Cosmos Hub") {
-                    address = CosmosBufferToAddress(keyPair.getPublicKeyBuffer());
-                    pubkey = CosmosBufferToPublic(keyPair.getPublicKeyBuffer());
+                    const hrp = "cosmos";
+                    address = CosmosBufferToAddress(keyPair.getPublicKeyBuffer(), hrp);
+                    pubkey = CosmosBufferToPublic(keyPair.getPublicKeyBuffer(), hrp);
                     privkey = keyPair.d.toBuffer().toString("base64");
+                }
+
+                if (networks[DOM.network.val()].name == "LUNA - Terra") {
+                    const hrp = "terra";
+                    address = CosmosBufferToAddress(keyPair.getPublicKeyBuffer(), hrp);
+                    pubkey = keyPair.getPublicKeyBuffer().toString("hex");
+                    privkey = keyPair.d.toBuffer().toString("hex");
                 }
 
                 //Groestlcoin Addresses are different
@@ -2937,6 +2945,13 @@
             onSelect: function() {
                 network = libs.bitcoin.networks.litecoinz;
                 setHdCoin(221);
+            },
+        },
+        {
+            name: "LUNA - Terra",
+            onSelect: function() {
+                network = libs.bitcoin.networks.bitcoin;
+                setHdCoin(330);
             },
         },
         {

--- a/tests/spec/tests.js
+++ b/tests/spec/tests.js
@@ -927,6 +927,16 @@ it('Allows selection of Cosmos Hub', function(done) {
     };
     testNetwork(done, params);
 });
+it('Allows selection of Terra', function(done) {
+    var params = {
+        selectText: "LUNA - Terra",
+        phrase: "abandon abandon ability",
+        firstAddress: "terra1txr4jwel3vjl64vrc08pljnjryqkhtffmyp265",
+        firstPubKey: "028e7658e3debb2d9d458919bfba0e85b0220e845f7552176f30a52acd0f809d71",
+        firstPrivKey: "d611b211e370aa1edd9743acd6ce537d16fade85d7ae7e88b32f3a0483f52535",
+    };
+    testNetwork(done, params);
+});
 it('Allows selection of Auroracoin', function(done) {
     var params = {
         selectText: "AUR - Auroracoin",


### PR DESCRIPTION
This PR adds Terra (LUNA) support. Terra is Cosmos-SDK based chain, using secp256k1 key pairs and the same bech32 address encoding as Cosmos Hub (ATOM).

Tests are consistent with other implementations such as github.com/terra-project/station and github.com/hukkinj1/cosmospy using DERIVATION_PATH = "m/44'/330'/0'/0/0"
BECH32_HRP = "terra"