### PR TITLE
Incorrect HTML closing tag

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -286,7 +286,7 @@
                                     for more information.
                                     </p>
                                 </div>
-                            </p>
+                            </div>
                             <label for="bip85-application" class="col-sm-2 control-label">BIP85 Application</label>
                             <div class="col-sm-10">
                                 <select id="bip85-application" class="form-control">


### PR DESCRIPTION
Fixed incorrect HTML closing tag, made it difficult to expand/collapse code folds correctly in text editors.