### PR TITLE
Add "auto compute" check box

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -182,6 +182,15 @@
                             </div>
                         </div>
                         <div class="form-group">
+                            <div class="col-sm-2"></div>
+                            <div class="col-sm-10 checkbox">
+                                <label>
+                                    <input type="checkbox" class="autoCompute" checked>
+                                    <span>Auto compute</span>
+                                </label>
+                            </div>
+                        </div>
+                        <div class="form-group">
                             <label class="col-sm-2 control-label">Mnemonic Language</label>
                             <div class="col-sm-10 languages">
                                 <div class="form-control no-border">

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -47,6 +47,7 @@
     DOM.entropyWeakEntropyOverrideWarning = DOM.entropyContainer.find(".weak-entropy-override-warning");
     DOM.entropyFilterWarning = DOM.entropyContainer.find(".filter-warning");
     DOM.phrase = $(".phrase");
+    DOM.autoCompute = $(".autoCompute");
     DOM.splitMnemonic = $(".splitMnemonic");
     DOM.showSplitMnemonic = $(".showSplitMnemonic");
     DOM.phraseSplit = $(".phraseSplit");
@@ -143,6 +144,7 @@
         DOM.network.on("change", networkChanged);
         DOM.bip32Client.on("change", bip32ClientChanged);
         DOM.useEntropy.on("change", setEntropyVisibility);
+        DOM.autoCompute.on("change", delayedPhraseChanged);
         DOM.entropy.on("input", delayedEntropyChanged);
         DOM.entropyMnemonicLength.on("change", entropyChanged);
         DOM.entropyTypeInputs.on("change", entropyTypeChanged);
@@ -234,6 +236,10 @@
         }
     }
 
+    function isUsingAutoCompute() {
+        return DOM.autoCompute.prop("checked");
+    }
+
     function setEntropyVisibility() {
         if (isUsingOwnEntropy()) {
             DOM.entropyContainer.removeClass("hidden");
@@ -251,6 +257,8 @@
     }
 
     function delayedPhraseChanged() {
+
+        if(isUsingAutoCompute()) {
         hideValidationError();
         seed = null;
         bip32RootKey = null;
@@ -270,6 +278,11 @@
                 entropyTypeAutoDetect = false;
             }
         }, 400);
+    } else {
+        clearDisplay();
+        clearEntropyFeedback();
+        showValidationError("Auto compute disabled");
+    }
     }
 
     function phraseChanged() {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -281,7 +281,7 @@
     } else {
         clearDisplay();
         clearEntropyFeedback();
-        showValidationError("Auto compute disabled");
+        showValidationError("Auto compute is disabled");
     }
     }
 


### PR DESCRIPTION
When checked, nothing change.

When unchecked, disable phraseChangeTimeoutEvent() so there is no update. Also, add an error message "Auto compute is disabled" so after changing phrase/passephrase and parameters, you are reminded to check "auto compute" to compute your seed.

I added this because on very low end computer (raspberry pi) the computing is quite annoying and you have to wait for each change.

When you add a custom words, seed is computed every 400ms so you have to copy/paste it to not be stuck after each letter.

And if you encrypt your private key with BIP38 it become unusable.

Autocompute is by default checked so there is no change for other users.