### PR TITLE
Add PBKDF2 customization

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -119,6 +119,18 @@
                                             </span>
                                         </p>
                                     </div>
+                                    <label class="col-sm-3 control-label">PBKDF2 rounds</label>
+                                    <div class="col-sm-9">
+                                        <select class="pbkdf2-rounds form-control" style="width: 60%;float: left;">
+                                            <option value="2048" selected>2048 <span>(compatibility)</span></option>
+                                            <option value="4096">4096 <span>iterations</span></option>
+                                            <option value="8192">8192 <span>iterations</span></option>
+                                            <option value="16384">16384 <span>iterations</span></option>
+                                            <option value="32768">32768 <span>iterations</span></option>
+                                            <option value="custom">Custom <span>iterations</span></option>
+                                        </select>
+                                        <input type="number" class="form-control hidden" id="pbkdf2-custom-input" value="1" min="1" pattern="[0-9]" style="float: right;width: 40%;">
+                                    </div>
                                 </div>
                                 <div class="col-sm-3">
                                     <p>Valid entropy values include:</p>
@@ -196,6 +208,13 @@
                                     <a href="#czech" title="Czech">Čeština</a>
                                     <a href="#portuguese" title="Portuguese">Português</a>
                                 </div>
+                            </div>
+                        </div>
+                        <div class="form-group text-danger PBKDF2-infos-danger hidden">
+                            <label class="col-sm-2 control-label">Warning</label>
+                            <div class="col-sm-10 form-control-static">
+                                <span>You are using a custom number of PBKDF2 iterations. Your BIP39 seed may not show same addresses on a different software.</span>
+                                <a href="#PBKDF2-notes">Read more</a>
                             </div>
                         </div>
                         <div class="form-group">
@@ -964,6 +983,12 @@
                             </a>
                         </span>
                     </p>
+                    <h3 id="PBKDF2-notes">PBKDF2</h3>
+                    <p><a href="https://learnmeabitcoin.com/technical/mnemonic#pbkdf2---password-based-key-derivation-function-2   " target="_blank">What is PBKDF2 (Password Based Key Derivation Function 2) ?</a></p>
+                    <p><span>Please refer to this <a href="https://en.wikipedia.org/wiki/PBKDF2" target="_blank">wikipedia article</a> for more detail.
+                    <span>Mail about PBKDF2 security <a href="https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2016-July/012902.html" target="_blank">here</a>.</p>
+                    <p>Wallet software that implement BIP39 only use 2048 iterations as a norm. Increasing this parameter will increase security against brute force attack, but you will need to store this new parameter. However, as long as you back up your BIP39 seed there will not be risk to lost your fund. To access them with custom PBKDF2 iterations, use this file (or <a href="https://stuff.birkenstab.de/pbkdf2/" target="_blank">other</a>) to compute your targeted BIP39 seed.</p>
+                    <p>Using less than 2048 PBKDF2 iterations is insecure without strong optional BIP39 Passphrase.</p>
                     <h3>License</h3>
                     <p>
                     <span>Please refer to <a href="https://github.com/iancoleman/bip39/blob/master/LICENSE" target="_blank">the software license</a> for more detail.

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -44,6 +44,9 @@
     DOM.entropyWordIndexes = DOM.entropyContainer.find(".word-indexes");
     DOM.entropyChecksum = DOM.entropyContainer.find(".checksum");
     DOM.entropyMnemonicLength = DOM.entropyContainer.find(".mnemonic-length");
+    DOM.pbkdf2Rounds = DOM.entropyContainer.find(".pbkdf2-rounds");
+    DOM.pbkdf2CustomInput = DOM.entropyContainer.find("#pbkdf2-custom-input");
+    DOM.pbkdf2InfosDanger = $(".PBKDF2-infos-danger");
     DOM.entropyWeakEntropyOverrideWarning = DOM.entropyContainer.find(".weak-entropy-override-warning");
     DOM.entropyFilterWarning = DOM.entropyContainer.find(".filter-warning");
     DOM.phrase = $(".phrase");
@@ -145,6 +148,8 @@
         DOM.useEntropy.on("change", setEntropyVisibility);
         DOM.entropy.on("input", delayedEntropyChanged);
         DOM.entropyMnemonicLength.on("change", entropyChanged);
+        DOM.pbkdf2Rounds.on("change", pbkdf2RoundsChanged);
+        DOM.pbkdf2CustomInput.on("change", pbkdf2RoundsChanged);
         DOM.entropyTypeInputs.on("change", entropyTypeChanged);
         DOM.phrase.on("input", delayedPhraseChanged);
         DOM.showSplitMnemonic.on("change", toggleSplitMnemonic);
@@ -336,6 +341,24 @@
         entropyChangeTimeoutEvent = setTimeout(entropyChanged, 400);
     }
 
+    function pbkdf2RoundsChanged() {
+        if (DOM.pbkdf2Rounds.val() == "custom") {
+            PBKDF2_ROUNDS = DOM.pbkdf2CustomInput.val();
+            DOM.pbkdf2CustomInput.removeClass("hidden");
+        } else {
+            PBKDF2_ROUNDS = DOM.pbkdf2Rounds.val();
+            DOM.pbkdf2CustomInput.addClass("hidden");
+        }
+        ispbkdf2Rounds2048();
+        phraseChanged();
+    }
+    function ispbkdf2Rounds2048() {
+        if (PBKDF2_ROUNDS == 2048) {
+            DOM.pbkdf2InfosDanger.addClass("hidden");
+        } else {
+            DOM.pbkdf2InfosDanger.removeClass("hidden");
+        }
+    }
     function entropyChanged() {
         // If blank entropy, clear mnemonic, addresses, errors
         if (DOM.entropy.val().trim().length == 0) {

--- a/src/js/jsbip39.js
+++ b/src/js/jsbip39.js
@@ -28,7 +28,9 @@
 
 var Mnemonic = function(language) {
 
-    var PBKDF2_ROUNDS = 2048;
+    var DOM = {};
+    DOM.entropyContainer = $(".entropy-container");
+    PBKDF2_ROUNDS = DOM.entropyContainer.find(".pbkdf2-rounds").val();
     var RADIX = 2048;
 
     var self = this;


### PR DESCRIPTION
- Add a "PBKDF2 rounds" button inside "Show Entropy Details" with values : 2048, 4096, 8192, 16384, 32768, custom.
- Add hidden button for custom iterations. Accept number.
- Add a Warning message above BIP39 seed when using anything other than 2048 PBKDF2 iterations.
- Add a "PBKDF2" section in the bottom for detail.