### PR TITLE
dx: add python shebang to compile script

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import os
 import re
 import datetime


### PR DESCRIPTION
This resolves "command not found" issue with `zsh` and other shells.