### PR TITLE
Fix switch to new language after manual input

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1780,7 +1780,7 @@
     function convertPhraseToNewLanguage() {
         var oldLanguage = getLanguageFromPhrase();
         var newLanguage = getLanguageFromUrl();
-        var oldPhrase = DOM.phrase.val();
+        var oldPhrase = DOM.phrase.val().normalize("NFKD");
         var oldWords = phraseToWordArray(oldPhrase);
         var newWords = [];
         for (var i=0; i<oldWords.length; i++) {


### PR DESCRIPTION
oldPhrase must be normalized before searching for words.
If not done, indexOf returns -1 on un-normalized words

The unnormalized words cannot be converted which induce broken mnemonic in new language.