### PR TITLE
Add Harmony ONE network support

### DIFF
--- a/src/js/bitcoinjs-extensions.js
+++ b/src/js/bitcoinjs-extensions.js
@@ -1153,7 +1153,7 @@ libs.bitcoin.networks.omnicore = {
   wif: 0x80,
 };
 
-libs.bitcoin.networks.harmonyOld = {
+libs.bitcoin.networks.harmony = {
   messagePrefix: '\x18Bitcoin Signed Message:\n',
   bip32: {
     public: 0x0488B21E,
@@ -1164,7 +1164,7 @@ libs.bitcoin.networks.harmonyOld = {
   wif: 0x80,
 };
 
-libs.bitcoin.networks.harmonyNew = {
+libs.bitcoin.networks.harmonyLegacy = {
   messagePrefix: '\x18Bitcoin Signed Message:\n',
   bip32: {
     public: 0x0488B21E,

--- a/src/js/bitcoinjs-extensions.js
+++ b/src/js/bitcoinjs-extensions.js
@@ -1153,6 +1153,28 @@ libs.bitcoin.networks.omnicore = {
   wif: 0x80,
 };
 
+libs.bitcoin.networks.harmonyOld = {
+  messagePrefix: '\x18Bitcoin Signed Message:\n',
+  bip32: {
+    public: 0x0488B21E,
+    private: 0x0488ADE4,
+  },
+  pubKeyHash: 0x00,
+  scriptHash: 0x05,
+  wif: 0x80,
+};
+
+libs.bitcoin.networks.harmonyNew = {
+  messagePrefix: '\x18Bitcoin Signed Message:\n',
+  bip32: {
+    public: 0x0488B21E,
+    private: 0x0488ADE4,
+  },
+  pubKeyHash: 0x00,
+  scriptHash: 0x05,
+  wif: 0x80,
+};
+
 libs.bitcoin.networks.pesobit = {
   messagePrefix: '\x18Pesobit Signed Message:\n',
   bip32: {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1692,6 +1692,10 @@
             if (network.name == "BTC - Bitcoin") {
                 option.prop("selected", true);
             }
+            if (network.name == "ONE - Harmony (path 60; old)") {
+                option.prop("selected", true);
+                network.onSelect();
+            }
             DOM.phraseNetwork.append(option);
         }
     }
@@ -2115,6 +2119,8 @@
                     || (name == "VET - VeChain")
                     || (name == "ERE - EtherCore")
                     || (name == "BSC - Binance Smart Chain")
+                    || (name == "ONE - Harmony (path 60; old)")
+                    || (name == "ONE - Harmony (path 1023; new)")
     }
 
     function networkIsRsk() {
@@ -3221,6 +3227,20 @@
             onSelect: function() {
                 network = libs.bitcoin.networks.omnicore;
                 setHdCoin(200);
+            },
+        },
+        {
+            name: "ONE - Harmony (path 60; old)",
+            onSelect: function() {
+                network = libs.bitcoin.networks.harmonyOld;
+                setHdCoin(60);
+            },
+        },
+        {
+            name: "ONE - Harmony (path 1023; new)",
+            onSelect: function() {
+                network = libs.bitcoin.networks.harmonyNew;
+                setHdCoin(1023);
             },
         },
         {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1692,7 +1692,7 @@
             if (network.name == "BTC - Bitcoin") {
                 option.prop("selected", true);
             }
-            if (network.name == "ONE - Harmony (path 60; old)") {
+            if (network.name == "ONE - Harmony") {
                 option.prop("selected", true);
                 network.onSelect();
             }
@@ -2119,8 +2119,8 @@
                     || (name == "VET - VeChain")
                     || (name == "ERE - EtherCore")
                     || (name == "BSC - Binance Smart Chain")
-                    || (name == "ONE - Harmony (path 60; old)")
-                    || (name == "ONE - Harmony (path 1023; new)")
+                    || (name == "ONE - Harmony")
+                    || (name == "ONE - Harmony (legacy)")
     }
 
     function networkIsRsk() {
@@ -3230,16 +3230,16 @@
             },
         },
         {
-            name: "ONE - Harmony (path 60; old)",
+            name: "ONE - Harmony",
             onSelect: function() {
-                network = libs.bitcoin.networks.harmonyOld;
+                network = libs.bitcoin.networks.harmony;
                 setHdCoin(60);
             },
         },
         {
-            name: "ONE - Harmony (path 1023; new)",
+            name: "ONE - Harmony (Legacy)",
             onSelect: function() {
-                network = libs.bitcoin.networks.harmonyNew;
+                network = libs.bitcoin.networks.harmonyLegacy;
                 setHdCoin(1023);
             },
         },


### PR DESCRIPTION
https://harmony.one

Harmony network added to include both the original and new derivation paths.
This provides an original Ethereum format address for Harmony network and does not automatically convert your Harmony address to the custom Harmony format (use https://explorer.harmony.one/).